### PR TITLE
fix: surface tool execution errors as tool_result (closes #7)

### DIFF
--- a/internal/runtime/query_runner.go
+++ b/internal/runtime/query_runner.go
@@ -772,9 +772,42 @@ func (r *QueryRunner) RunMessages(
 							}
 							return
 						}
-						errType = "tool_error"
-						errs <- err
-						return
+						errMsg := err.Error()
+						toolErrMsg := &message.AssistantMessage{
+							Type:  "assistant",
+							Model: reqModel,
+							Content: []message.ContentBlock{
+								&message.ToolResultBlock{
+									Type:      message.BlockTypeToolResult,
+									ToolUseID: c.ID,
+									IsError:   true,
+									Content: []message.ContentBlock{
+										&message.TextBlock{Type: message.BlockTypeText, Text: errMsg},
+									},
+								},
+							},
+						}
+						attachAuditEnvelope(toolErrMsg, "assistant", "tool_result", toolErrMsg)
+						select {
+						case out <- toolErrMsg:
+						case <-ctx.Done():
+							errs <- ctx.Err()
+							return
+						}
+						toolCalls = append(toolCalls, map[string]any{
+							"id":   c.ID,
+							"type": "function",
+							"function": map[string]any{
+								"name":      c.Name,
+								"arguments": c.Args.String(),
+							},
+						})
+						toolResultsHistory = append(toolResultsHistory, map[string]any{
+							"role":         "tool",
+							"tool_call_id": c.ID,
+							"content":      errMsg,
+						})
+						continue
 					}
 					// Unset span status implies success.
 					toolSpan.End()

--- a/internal/runtime/query_runner_tool_error_test.go
+++ b/internal/runtime/query_runner_tool_error_test.go
@@ -1,0 +1,125 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/ethpandaops/openrouter-agent-sdk-go/internal/config"
+	"github.com/ethpandaops/openrouter-agent-sdk-go/internal/mcp"
+	"github.com/ethpandaops/openrouter-agent-sdk-go/internal/message"
+	"github.com/ethpandaops/openrouter-agent-sdk-go/internal/session"
+)
+
+// erroringToolServer mimics an MCP SDK server whose CallTool returns a Go
+// error (e.g. wagie's execute tool wrapping a SyntaxError). A CallToolResult
+// with IsError=true is NOT the same path — this reproduces the Go-error path
+// specifically.
+type erroringToolServer struct {
+	calls int
+}
+
+func (s *erroringToolServer) Name() string    { return "srv" }
+func (s *erroringToolServer) Version() string { return "1.0.0" }
+func (s *erroringToolServer) ListTools() []map[string]any {
+	return []map[string]any{
+		{
+			"name":        "echo",
+			"description": "echo",
+			"inputSchema": map[string]any{"type": "object"},
+		},
+	}
+}
+
+func (s *erroringToolServer) CallTool(
+	_ context.Context,
+	_ string,
+	_ map[string]any,
+) (map[string]any, error) {
+	s.calls++
+	return nil, fmt.Errorf("running execute code: %w", fmt.Errorf("SyntaxError: unexpected token"))
+}
+
+// TestRunMessagesToolErrorSurfacesAsToolResult proves the bug described in
+// issue #7: when an MCP tool's CallTool returns a Go error, the SDK should
+// feed an is_error tool_result back to the model so it can self-correct —
+// not terminate the session by pushing the error onto the errs channel.
+//
+// With the current implementation (query_runner.go:775-777) this test fails:
+//   - the error is forwarded on errs
+//   - no ToolResultBlock reaches the model
+//   - the transport is only invoked once (no follow-up turn)
+func TestRunMessagesToolErrorSurfacesAsToolResult(t *testing.T) {
+	tr := &toolCallTransport{}
+	srv := &erroringToolServer{}
+	opts := &config.Options{
+		Transport: tr,
+		MCPServers: map[string]mcp.ServerConfig{
+			"srv": &mcp.SdkServerConfig{Type: mcp.ServerTypeSDK, Name: "srv", Instance: srv},
+		},
+		MaxTurns: 2,
+	}
+	r := NewQueryRunner(opts, session.NewManager(), nil)
+
+	msgs, errs := r.RunPrompt(context.Background(), "default", message.NewUserMessageContent("hello"))
+
+	var (
+		toolResult   *message.ToolResultBlock
+		resultMsg    *message.ResultMessage
+		assistantSaw int
+	)
+	for msg := range msgs {
+		switch m := msg.(type) {
+		case *message.AssistantMessage:
+			assistantSaw++
+			for _, block := range m.Content {
+				if trb, ok := block.(*message.ToolResultBlock); ok {
+					toolResult = trb
+				}
+			}
+		case *message.ResultMessage:
+			resultMsg = m
+		}
+	}
+	var gotErr error
+	for err := range errs {
+		if err != nil {
+			gotErr = err
+		}
+	}
+
+	if gotErr != nil {
+		t.Fatalf("tool error should not terminate the session, but got err: %v", gotErr)
+	}
+	if srv.calls != 1 {
+		t.Fatalf("expected exactly one tool invocation, got %d", srv.calls)
+	}
+	if toolResult == nil {
+		t.Fatal("expected an is_error ToolResultBlock to be emitted back to the model")
+	}
+	if !toolResult.IsError {
+		t.Fatalf("expected ToolResultBlock.IsError=true, got %+v", toolResult)
+	}
+	if len(toolResult.Content) == 0 {
+		t.Fatalf("expected error text in ToolResultBlock.Content, got %+v", toolResult)
+	}
+	if tb, ok := toolResult.Content[0].(*message.TextBlock); !ok || !strings.Contains(tb.Text, "SyntaxError") {
+		t.Fatalf("expected SyntaxError text in tool result, got %+v", toolResult.Content[0])
+	}
+	if toolResult.ToolUseID != "call_1" {
+		t.Fatalf("expected ToolUseID to match the failing tool_use id, got %q", toolResult.ToolUseID)
+	}
+	if tr.call < 2 {
+		t.Fatalf("expected a follow-up turn after tool failure, transport called %d times", tr.call)
+	}
+	if resultMsg == nil {
+		t.Fatal("expected a terminal ResultMessage")
+	}
+	if resultMsg.IsError {
+		t.Fatalf("session should finish cleanly after the model self-corrects, got error result: %+v", resultMsg)
+	}
+	if assistantSaw == 0 {
+		t.Fatalf("expected at least one assistant message to be emitted")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #7 — when an MCP tool's `CallTool` returned a Go error, the SDK aborted the entire query loop instead of feeding the error back to the model as a `tool_result` block. A single broken tool call killed the session even though the model could trivially recover from the error text.

## What changed

- **`internal/runtime/query_runner.go`** — in the `ExecuteWithSuggestions` error branch, replaced `errs <- err; return` with:
  - emission of an `is_error: true` `ToolResultBlock` containing the error message, addressed to the failing `tool_use` id;
  - appending the call + error text to `toolCalls` and `toolResultsHistory` so the follow-up turn carries the failure;
  - `continue` to the next tool call in the batch (previously the whole run aborted on the first failure).
- **`ToolPermissionDeniedError` with `Interrupt: true`** path is preserved unchanged — that is the only tool failure that should terminate the session with an error `ResultMessage`.
- Observability side-effects (`RecordToolCall` outcome=`error`, span error, `PostToolUseFailure` hook) already fire before the branch and are unaffected.

## Before vs after

Reproducer: `moonshotai/kimi-k2.6` calling an MCP `execute` tool whose `CallTool` returned `fmt.Errorf(\"running execute code: %w\", syntaxErr)`.

- **Before**: session terminated with `calling \"tools/call\": running execute code: SyntaxError: ...`; no further turns ran; model never saw the failure.
- **After**: an `is_error` `tool_result` with the `SyntaxError` text is sent back to the model; the next turn runs; model can fix the script and retry.

## Test plan

Added `TestRunMessagesToolErrorSurfacesAsToolResult` in `internal/runtime/query_runner_tool_error_test.go`. It:

- wires an MCP SDK server whose `CallTool` returns a Go error (matching the wagie case),
- drives the query loop with the existing `toolCallTransport` (tool call turn 1 → `done` turn 2),
- asserts that **no error** escapes on the `errs` channel,
- asserts an `is_error: true` `ToolResultBlock` addressed to the failing `tool_use` id is emitted back to the model,
- asserts the transport is invoked a second time (follow-up turn ran),
- asserts the run completes with a non-error `ResultMessage`.

The test was written first and verified to fail on `master` with the exact message from the issue; it passes after this change.

- [x] `go build ./...`
- [x] `go test -race ./...` — all green
- [x] `golangci-lint run --new-from-rev=\"origin/master\"` — 0 issues

## Related

- ethpandaops/wagie#348 — the upstream producer of the specific Go error that surfaced this latent trap. Fixing wagie alone would have hidden the symptom; this PR fixes the SDK behavior for any MCP server whose tools can fail with a Go error.

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)