### PR TITLE
fix: use ctx + idle deadline for SSE streams instead of http.Client.Timeout

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -45,6 +45,9 @@ var (
 	// ErrRequestTimeout indicates a request timed out.
 	ErrRequestTimeout = internalerrors.ErrRequestTimeout
 
+	// ErrStreamIdle indicates a streaming response produced no data within the configured idle window.
+	ErrStreamIdle = internalerrors.ErrStreamIdle
+
 	// ErrSessionNotFound indicates a requested local session does not exist.
 	ErrSessionNotFound = internalerrors.ErrSessionNotFound
 

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -124,13 +124,15 @@ type Options struct {
 	Observer *observability.Observer
 
 	// OpenRouter specific
-	APIKey            string
-	BaseURL           string
-	OpenRouterAPIMode OpenRouterAPIMode
-	HTTPReferer       string
-	XTitle            string
-	RequestTimeout    *time.Duration
-	MaxToolIterations int
+	APIKey                string
+	BaseURL               string
+	OpenRouterAPIMode     OpenRouterAPIMode
+	HTTPReferer           string
+	XTitle                string
+	RequestTimeout        *time.Duration
+	StreamIdleTimeout     *time.Duration
+	ResponseHeaderTimeout *time.Duration
+	MaxToolIterations     int
 
 	// OpenRouter request fields
 	OpenRouterTopP               *float64

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -36,6 +36,9 @@ var (
 	// ErrRequestTimeout indicates a request timed out.
 	ErrRequestTimeout = errors.New("request timeout")
 
+	// ErrStreamIdle indicates a streaming response produced no data within the idle timeout window.
+	ErrStreamIdle = errors.New("stream idle timeout")
+
 	// ErrSessionNotFound indicates a requested local session could not be found.
 	ErrSessionNotFound = errors.New("session not found")
 

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -316,6 +316,7 @@ func newErrorRegistry() *agenterrclass.Registry {
 	// RegisterDefaults().
 	reg.RegisterSentinel(sdkerrors.ErrOperationCancelled, agenterrclass.Canceled)
 	reg.RegisterSentinel(sdkerrors.ErrRequestTimeout, agenterrclass.Timeout)
+	reg.RegisterSentinel(sdkerrors.ErrStreamIdle, agenterrclass.Timeout)
 
 	reg.RegisterMatcher(func(err error) (agenterrclass.Class, bool) {
 		var typed *sdkerrors.ToolPermissionDeniedError

--- a/internal/openrouter/http_client.go
+++ b/internal/openrouter/http_client.go
@@ -14,8 +14,15 @@ import (
 
 	"github.com/ethpandaops/agent-sdk-observability/semconv/httpconv"
 	"github.com/ethpandaops/openrouter-agent-sdk-go/internal/config"
+	internalerrors "github.com/ethpandaops/openrouter-agent-sdk-go/internal/errors"
 	"github.com/ethpandaops/openrouter-agent-sdk-go/internal/observability"
 	"github.com/ethpandaops/openrouter-agent-sdk-go/internal/util"
+)
+
+// Default timeout values for the streaming SSE transport.
+const (
+	defaultStreamIdleTimeout     = 120 * time.Second
+	defaultResponseHeaderTimeout = 30 * time.Second
 )
 
 // HTTPTransport implements config.Transport against OpenRouter chat completions.
@@ -31,16 +38,34 @@ type HTTPTransport struct {
 }
 
 // NewHTTPTransport creates an OpenRouter HTTP transport.
+//
+// The returned *http.Client intentionally has no Client.Timeout set: that
+// field is a hard wall-clock on the entire request lifecycle including body
+// read, which would kill SSE streams mid-body on long reasoning turns. The
+// streaming path relies on:
+//   - ctx cancellation (and, when opts.RequestTimeout is set, a context.WithTimeout
+//     derived from it in CreateStream) for overall budget
+//   - Transport.ResponseHeaderTimeout for a "time to first byte" bound
+//   - a per-stream idle reader (opts.StreamIdleTimeout) for stuck connections
 func NewHTTPTransport(opts *config.Options) *HTTPTransport {
-	timeout := 60 * time.Second
-	if opts != nil && opts.RequestTimeout != nil {
-		timeout = *opts.RequestTimeout
+	headerTimeout := defaultResponseHeaderTimeout
+	if opts != nil && opts.ResponseHeaderTimeout != nil {
+		headerTimeout = *opts.ResponseHeaderTimeout
 	}
+
+	transport, _ := http.DefaultTransport.(*http.Transport)
+	if transport != nil {
+		transport = transport.Clone()
+	} else {
+		transport = &http.Transport{}
+	}
+	transport.ResponseHeaderTimeout = headerTimeout
+
 	return &HTTPTransport{
 		opts: opts,
 		obs:  observability.Noop(),
 		client: &http.Client{
-			Timeout: timeout,
+			Transport: transport,
 		},
 	}
 }
@@ -90,7 +115,21 @@ func (t *HTTPTransport) CreateStream(ctx context.Context, req *config.ChatReques
 			}
 		}()
 
-		if err := t.Start(ctx); err != nil {
+		// Optional overall wall-clock budget. When RequestTimeout is set, apply
+		// it as a context deadline rather than http.Client.Timeout so the stream
+		// body read is bounded by the caller's ctx rather than a transport-level
+		// hard cap that kills progressing streams.
+		if t.opts != nil && t.opts.RequestTimeout != nil {
+			var cancelDeadline context.CancelFunc
+			ctx, cancelDeadline = context.WithTimeout(ctx, *t.opts.RequestTimeout)
+			defer cancelDeadline()
+		}
+
+		// Child context used to abort the stream on idle-read timeout.
+		streamCtx, cancelStream := context.WithCancel(ctx)
+		defer cancelStream()
+
+		if err := t.Start(streamCtx); err != nil {
 			errs <- err
 			close(out)
 			close(errs)
@@ -107,7 +146,7 @@ func (t *HTTPTransport) CreateStream(ctx context.Context, req *config.ChatReques
 			return
 		}
 
-		resp, err := t.doRequest(ctx, payload)
+		resp, err := t.doRequest(streamCtx, payload)
 		if err != nil {
 			errs <- err
 			close(out)
@@ -125,7 +164,19 @@ func (t *HTTPTransport) CreateStream(ctx context.Context, req *config.ChatReques
 			return
 		}
 
-		util.ParseSSE(ctx, resp.Body, out, errs)
+		idleTimeout := defaultStreamIdleTimeout
+		if t.opts != nil && t.opts.StreamIdleTimeout != nil {
+			idleTimeout = *t.opts.StreamIdleTimeout
+		}
+
+		var reader io.Reader = resp.Body
+		if idleTimeout > 0 {
+			idle := util.NewIdleReader(resp.Body, idleTimeout, internalerrors.ErrStreamIdle, cancelStream)
+			defer idle.Stop()
+			reader = idle
+		}
+
+		util.ParseSSE(streamCtx, reader, out, errs)
 	}()
 
 	return out, errs

--- a/internal/openrouter/http_client_stream_test.go
+++ b/internal/openrouter/http_client_stream_test.go
@@ -1,0 +1,146 @@
+package openrouter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ethpandaops/openrouter-agent-sdk-go/internal/config"
+	internalerrors "github.com/ethpandaops/openrouter-agent-sdk-go/internal/errors"
+)
+
+// TestCreateStream_SlowButProgressing ensures the default short request
+// timeout does not kill a stream that is slowly but steadily emitting data.
+// This is a regression guard for issue #9: http.Client.Timeout used to cap
+// the full body-read window.
+func TestCreateStream_SlowButProgressing(t *testing.T) {
+	const chunkDelay = 40 * time.Millisecond
+	const chunks = 5
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		for i := range chunks {
+			time.Sleep(chunkDelay)
+			_, _ = fmt.Fprintf(w, "data: {\"i\":%d}\n\n", i)
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}))
+	defer srv.Close()
+
+	// Overall budget shorter than the old Client.Timeout-style total body
+	// duration (5 * 40ms = 200ms) would have been rejected; idle budget is
+	// long enough that per-chunk progress keeps it alive.
+	idle := 150 * time.Millisecond
+	opts := &config.Options{
+		BaseURL:           srv.URL,
+		APIKey:            "sk-test",
+		StreamIdleTimeout: &idle,
+	}
+	tr := NewHTTPTransport(opts)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	out, errs := tr.CreateStream(ctx, &config.ChatRequest{
+		Model:    "test",
+		Messages: []map[string]any{{"role": "user", "content": "hi"}},
+	})
+
+	got := 0
+	for msg := range out {
+		if _, ok := msg["i"]; ok {
+			got++
+		}
+	}
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("unexpected stream error: %v", err)
+		}
+	}
+	if got != chunks {
+		t.Fatalf("expected %d data chunks, got %d", chunks, got)
+	}
+}
+
+// TestCreateStream_IdleStall ensures a stalled stream is aborted with
+// ErrStreamIdle when no data arrives within StreamIdleTimeout.
+func TestCreateStream_IdleStall(t *testing.T) {
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		// Never emit data. Unblocks only when the test tears down.
+		select {
+		case <-block:
+		case <-r.Context().Done():
+		}
+	}))
+	defer func() {
+		close(block)
+		srv.Close()
+	}()
+
+	idle := 80 * time.Millisecond
+	opts := &config.Options{
+		BaseURL:           srv.URL,
+		APIKey:            "sk-test",
+		StreamIdleTimeout: &idle,
+	}
+	tr := NewHTTPTransport(opts)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	out, errs := tr.CreateStream(ctx, &config.ChatRequest{
+		Model:    "test",
+		Messages: []map[string]any{{"role": "user", "content": "hi"}},
+	})
+
+	for range out {
+		// drain
+	}
+
+	var seen error
+	for err := range errs {
+		if err != nil {
+			seen = err
+		}
+	}
+	if seen == nil {
+		t.Fatalf("expected stream error, got nil")
+	}
+	if !errors.Is(seen, internalerrors.ErrStreamIdle) {
+		t.Fatalf("expected ErrStreamIdle, got %v", seen)
+	}
+}
+
+// TestNewHTTPTransport_NoClientTimeout documents the invariant: the streaming
+// client must never have http.Client.Timeout set, since that caps body read.
+func TestNewHTTPTransport_NoClientTimeout(t *testing.T) {
+	timeout := 5 * time.Second
+	tr := NewHTTPTransport(&config.Options{RequestTimeout: &timeout})
+	if tr.client.Timeout != 0 {
+		t.Fatalf("expected client.Timeout=0, got %s", tr.client.Timeout)
+	}
+	httpTransport, ok := tr.client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", tr.client.Transport)
+	}
+	if httpTransport.ResponseHeaderTimeout == 0 {
+		t.Fatalf("expected ResponseHeaderTimeout to be set")
+	}
+}

--- a/internal/util/idle_reader.go
+++ b/internal/util/idle_reader.go
@@ -1,0 +1,90 @@
+package util
+
+import (
+	"io"
+	"sync"
+	"time"
+)
+
+// IdleReader wraps an io.Reader and enforces an idle-read timeout. The
+// internal timer is reset on every successful (n>0) Read; if the timer
+// expires before another read completes, onIdle is invoked and subsequent
+// Read calls return the error supplied by onIdle's caller via the wrapper's
+// state. The zero timeout disables the timer (behaves as a plain pass-through).
+type IdleReader struct {
+	r       io.Reader
+	timeout time.Duration
+	idleErr error
+	onIdle  func()
+	mu      sync.Mutex
+	timer   *time.Timer
+	fired   bool
+	stopped bool
+}
+
+// NewIdleReader constructs an IdleReader. onIdle is called once, asynchronously,
+// from the timer goroutine when the idle window elapses — typically used to
+// cancel a context so the underlying Read unblocks. idleErr is substituted for
+// any error returned by the underlying reader after the timer has fired so
+// callers can distinguish idle timeout from generic network/context errors.
+func NewIdleReader(r io.Reader, timeout time.Duration, idleErr error, onIdle func()) *IdleReader {
+	ir := &IdleReader{
+		r:       r,
+		timeout: timeout,
+		idleErr: idleErr,
+		onIdle:  onIdle,
+	}
+	if timeout > 0 {
+		ir.timer = time.AfterFunc(timeout, ir.fire)
+	}
+	return ir
+}
+
+// Read implements io.Reader.
+func (ir *IdleReader) Read(p []byte) (int, error) {
+	if ir.hasFired() {
+		return 0, ir.idleErr
+	}
+	n, err := ir.r.Read(p)
+	if n > 0 {
+		ir.mu.Lock()
+		if !ir.fired && !ir.stopped && ir.timer != nil {
+			ir.timer.Reset(ir.timeout)
+		}
+		ir.mu.Unlock()
+	}
+	if err != nil && ir.hasFired() {
+		err = ir.idleErr
+	}
+	return n, err
+}
+
+// Stop halts the idle timer. Safe to call multiple times.
+func (ir *IdleReader) Stop() {
+	ir.mu.Lock()
+	defer ir.mu.Unlock()
+	ir.stopped = true
+	if ir.timer != nil {
+		ir.timer.Stop()
+	}
+}
+
+func (ir *IdleReader) fire() {
+	ir.mu.Lock()
+	if ir.stopped {
+		ir.mu.Unlock()
+		return
+	}
+	ir.fired = true
+	cb := ir.onIdle
+	ir.mu.Unlock()
+	if cb != nil {
+		cb()
+	}
+}
+
+func (ir *IdleReader) hasFired() bool {
+	ir.mu.Lock()
+	defer ir.mu.Unlock()
+	return ir.fired
+}

--- a/internal/util/idle_reader_test.go
+++ b/internal/util/idle_reader_test.go
@@ -1,0 +1,134 @@
+package util
+
+import (
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+)
+
+// slowReader emits configured chunks with a delay in between.
+type slowReader struct {
+	chunks []string
+	delay  time.Duration
+	idx    int
+}
+
+func (s *slowReader) Read(p []byte) (int, error) {
+	if s.idx >= len(s.chunks) {
+		return 0, io.EOF
+	}
+	if s.idx > 0 {
+		time.Sleep(s.delay)
+	}
+	n := copy(p, s.chunks[s.idx])
+	s.idx++
+	return n, nil
+}
+
+// stuckReader blocks indefinitely on Read until closed via ctx/timer expiry.
+type stuckReader struct{ done chan struct{} }
+
+func (s *stuckReader) Read(p []byte) (int, error) {
+	<-s.done
+	return 0, io.EOF
+}
+
+var errIdleSentinel = errors.New("idle sentinel")
+
+func TestIdleReader_ResetsOnProgress(t *testing.T) {
+	// Four 20ms chunks with 80ms idle timeout must succeed because each
+	// Read resets the timer.
+	r := &slowReader{
+		chunks: []string{"a", "b", "c", "d"},
+		delay:  20 * time.Millisecond,
+	}
+	fired := make(chan struct{}, 1)
+	ir := NewIdleReader(r, 80*time.Millisecond, errIdleSentinel, func() {
+		fired <- struct{}{}
+	})
+	defer ir.Stop()
+
+	buf := make([]byte, 1)
+	var total int
+	for {
+		n, err := ir.Read(buf)
+		total += n
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	}
+	if total != 4 {
+		t.Fatalf("expected 4 bytes, got %d", total)
+	}
+	select {
+	case <-fired:
+		t.Fatalf("idle fired on progressing stream")
+	default:
+	}
+}
+
+func TestIdleReader_FiresOnStall(t *testing.T) {
+	stuck := &stuckReader{done: make(chan struct{})}
+	var once sync.Once
+	unblock := func() { once.Do(func() { close(stuck.done) }) }
+	t.Cleanup(unblock)
+
+	fired := make(chan struct{}, 1)
+	ir := NewIdleReader(stuck, 30*time.Millisecond, errIdleSentinel, func() {
+		unblock()
+		fired <- struct{}{}
+	})
+	defer ir.Stop()
+
+	buf := make([]byte, 1)
+	_, err := ir.Read(buf)
+	if !errors.Is(err, errIdleSentinel) {
+		t.Fatalf("expected idle sentinel, got %v", err)
+	}
+
+	select {
+	case <-fired:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("onIdle callback never fired")
+	}
+}
+
+func TestIdleReader_StopPreventsFire(t *testing.T) {
+	stuck := &stuckReader{done: make(chan struct{})}
+	t.Cleanup(func() { close(stuck.done) })
+
+	fired := make(chan struct{}, 1)
+	ir := NewIdleReader(stuck, 20*time.Millisecond, errIdleSentinel, func() {
+		fired <- struct{}{}
+	})
+	ir.Stop()
+
+	time.Sleep(60 * time.Millisecond)
+	select {
+	case <-fired:
+		t.Fatalf("onIdle fired after Stop")
+	default:
+	}
+}
+
+func TestIdleReader_ZeroTimeoutDisables(t *testing.T) {
+	r := &slowReader{chunks: []string{"x"}}
+	ir := NewIdleReader(r, 0, errIdleSentinel, func() {
+		t.Fatalf("onIdle should not fire when timeout=0")
+	})
+	defer ir.Stop()
+
+	buf := make([]byte, 1)
+	n, err := ir.Read(buf)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 byte, got %d", n)
+	}
+}

--- a/internal/util/sse.go
+++ b/internal/util/sse.go
@@ -74,9 +74,13 @@ func ParseSSE(ctx context.Context, r io.Reader, out chan<- map[string]any, errs 
 		flush()
 	}
 	if err := scanner.Err(); err != nil && !errors.Is(err, io.EOF) {
+		// Non-blocking send so an ctx-cancelled idle-timeout still surfaces
+		// the underlying error rather than being swallowed by ctx.Done().
+		// errs is buffered by the caller; dropping on overflow is acceptable
+		// because prior errors already describe the failure.
 		select {
 		case errs <- err:
-		case <-ctx.Done():
+		default:
 		}
 	}
 }

--- a/options.go
+++ b/options.go
@@ -326,10 +326,38 @@ func WithXTitle(title string) Option {
 	}
 }
 
-// WithRequestTimeout sets HTTP request timeout for OpenRouter calls.
+// WithRequestTimeout sets an overall wall-clock budget for a single OpenRouter
+// streaming call, applied via context deadline. This covers the complete
+// lifecycle (connect, headers, and full body stream) of one chat completion
+// request including any internal retries.
+//
+// For long reasoning turns or tool retries that stream for extended periods,
+// prefer leaving this unset (default: no overall deadline) and rely on
+// WithStreamIdleTimeout to fail fast on stuck connections. If set, pick a
+// value generous enough to accommodate the slowest turn you expect.
 func WithRequestTimeout(timeout time.Duration) Option {
 	return func(o *OpenRouterAgentOptions) {
 		o.RequestTimeout = &timeout
+	}
+}
+
+// WithStreamIdleTimeout sets the maximum time an SSE stream may produce no
+// bytes before the request is aborted with ErrStreamIdle. The timer resets on
+// every read that returns data (including OpenRouter keepalive comments), so
+// long-but-progressing streams are not affected. Defaults to 120s. Set to 0
+// to disable.
+func WithStreamIdleTimeout(timeout time.Duration) Option {
+	return func(o *OpenRouterAgentOptions) {
+		o.StreamIdleTimeout = &timeout
+	}
+}
+
+// WithResponseHeaderTimeout sets the maximum time to wait for response
+// headers (time to first byte) on OpenRouter requests. This does not apply to
+// body streaming. Defaults to 30s.
+func WithResponseHeaderTimeout(timeout time.Duration) Option {
+	return func(o *OpenRouterAgentOptions) {
+		o.ResponseHeaderTimeout = &timeout
 	}
 }
 


### PR DESCRIPTION
## Summary

- Remove `http.Client.Timeout` from the streaming transport — that field caps the entire request lifecycle including body read, which kills SSE streams mid-body on long reasoning turns (surfaces as `context deadline exceeded (Client.Timeout or context cancellation while reading body)`).
- Replace it with a layered model: `Transport.ResponseHeaderTimeout` for time-to-first-byte, `context.WithTimeout` derived from `opts.RequestTimeout` for the overall wall-clock budget, and a new `util.IdleReader` that resets a timer on every SSE read and fails fast with `ErrStreamIdle` when the stream stalls.
- Leave the non-streaming `/models` path alone — `Client.Timeout` is correct there.

Closes #9

## What changed

**Transport wiring (`internal/openrouter/http_client.go`)**
- `NewHTTPTransport` clones `http.DefaultTransport` and sets `ResponseHeaderTimeout` (default `30s`); no `Client.Timeout`.
- `CreateStream` applies `opts.RequestTimeout` as `context.WithTimeout` when set, derives a cancellable child ctx for the stream, and wraps `resp.Body` in an `IdleReader` that cancels the child ctx on idle.

**Idle reader (`internal/util/idle_reader.go`)**
- `time.AfterFunc`-backed wrapper. Reset on every non-zero read; substitutes the supplied sentinel (`ErrStreamIdle`) once fired so callers can distinguish idle timeout from generic ctx cancellation.

**Error plumbing**
- New sentinel `ErrStreamIdle` in `internal/errors` + re-export.
- Registered as `Timeout` class in the observability registry.
- `ParseSSE` terminal error send is now non-blocking — an idle-cancelled ctx no longer swallows the underlying error.

**Config / SDK surface**
- `config.Options` adds `StreamIdleTimeout *time.Duration` (default `120s`) and `ResponseHeaderTimeout *time.Duration` (default `30s`).
- New options: `WithStreamIdleTimeout`, `WithResponseHeaderTimeout`.
- `WithRequestTimeout` docstring rewritten to clarify it is now an overall wall-clock applied via ctx deadline — no longer an `http.Client.Timeout`. Default went from `60s` to unset; callers who want a hard cap opt in.

## Defaults

| Knob | Before | After |
|---|---|---|
| Overall wall-clock | `60s` via `Client.Timeout` on every request | unset; opt-in via `WithRequestTimeout` applied as ctx deadline |
| Time-to-first-byte | n/a (rolled into the 60s above) | `30s` via `ResponseHeaderTimeout` |
| Stream idle | n/a | `120s` via `IdleReader`, reset per read |

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run --new-from-rev="origin/master" ./...` — 0 issues
- [x] `go test ./... -race -count=1` — all packages pass
- [x] New `internal/util/idle_reader_test.go` — covers progressing streams (no false fire), stall detection, `Stop()` cancellation, zero-timeout passthrough
- [x] New `internal/openrouter/http_client_stream_test.go` — httptest integration: slow-but-progressing SSE stream succeeds, stalled stream fails with `ErrStreamIdle`, invariant that `NewHTTPTransport` leaves `Client.Timeout == 0`

## Migration notes

Users previously relying on the implicit 60s cap to bound runaway requests should set `WithRequestTimeout` explicitly. For interactive agent loops with reasoning models, leaving `RequestTimeout` unset and relying on the idle timeout is the recommended configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)